### PR TITLE
Component Modules and Static @Provides

### DIFF
--- a/app/src/main/java/com/thedancercodes/daggersandbox/AuthActivity.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/AuthActivity.java
@@ -16,11 +16,15 @@ public class AuthActivity extends DaggerAppCompatActivity {
     @Inject
     String cndhdfh;
 
+    @Inject
+    boolean isAppNull;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_auth);
 
         Log.d(TAG, "onCreate: " + cndhdfh);
+        Log.d(TAG, "onCreate: is app null? " +  isAppNull);
     }
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
@@ -15,9 +15,4 @@ public abstract class ActivityBuildersModule {
     @ContributesAndroidInjector
     abstract AuthActivity contributeAuthActivity();
 
-    @Provides
-    static String someString(){
-        return "this is a test string";
-    }
-
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppComponent.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppComponent.java
@@ -22,6 +22,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
         modules = {
                 AndroidSupportInjectionModule.class,
                 ActivityBuildersModule.class,
+                AppModule.class,
         }
 )
 public interface AppComponent extends AndroidInjector<BaseApplication> {

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
@@ -1,0 +1,29 @@
+package com.thedancercodes.daggersandbox.di;
+
+import android.app.Application;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * AppModule will be used inside the AppComponent.
+ *
+ * All the application level dependencies for the project will be contained here (e.g) Retrofit
+ * instance, Glide instance; anything that will exist & won't change for the entire lifetime of
+ * the application.
+ */
+
+@Module
+public class AppModule {
+
+    @Provides
+    static String someString(){
+        return "this is a test string";
+    }
+
+    @Provides
+    static boolean getApp(Application application) {
+        // If application is null, this returns true & vice versa.
+        return application == null;
+    }
+}


### PR DESCRIPTION
* Creating sub-modules within a component.
* `@Provides` annotation is used to declare a dependency. **Example**: Create this dependency when a string is injected into an Activity.
* Reference other dependencies within the same module.
* **NOTE**: `@BindInstance` binds an object when the component is built and the said object can be used inside any of the modules related to the component.
* See the simple example of boolean injection into the **AuthActivity**.