### PR TITLE
Singleton Scope with Dagger 2

### DIFF
--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppComponent.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppComponent.java
@@ -4,6 +4,8 @@ import android.app.Application;
 
 import com.thedancercodes.daggersandbox.BaseApplication;
 
+import javax.inject.Singleton;
+
 import dagger.BindsInstance;
 import dagger.Component;
 import dagger.android.AndroidInjector;
@@ -18,6 +20,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
  * Here we inject BaseApplication into AppComponent & BaseApplication will be a client of the
  * AppComponent service.
  */
+@Singleton
 @Component(
         modules = {
                 AndroidSupportInjectionModule.class,

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
@@ -10,6 +10,8 @@ import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.request.RequestOptions;
 import com.thedancercodes.daggersandbox.R;
 
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 
@@ -24,6 +26,7 @@ import dagger.Provides;
 @Module
 public class AppModule {
 
+    @Singleton
     @Provides
     static RequestOptions provideRequestOptions() {
         return RequestOptions
@@ -33,6 +36,7 @@ public class AppModule {
 
     // This dependency provides the Glide instance.
     // It depends on the RequestOptions dependency above.
+    @Singleton
     @Provides
     static RequestManager provideGlideInstance(Application application,
                                                RequestOptions requestOptions) {
@@ -40,6 +44,7 @@ public class AppModule {
                 .setDefaultRequestOptions(requestOptions);
     }
 
+    @Singleton
     @Provides
     static Drawable provideAppDrawable(Application application) {
         return ContextCompat.getDrawable(application, R.drawable.logo);


### PR DESCRIPTION
* Annotate AppComponent &  app dependencies with the `@Singleton`. This lets dagger know that it should persist and be left in memory.
* **NOTE**: The AppComponent owns the `@Singleton` scope.