### PR TITLE
Injecting ViewModels with Dagger 2 on Android (Map MultiBindings)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,4 +51,9 @@ dependencies {
     def glide_version = "4.11.0"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     annotationProcessor "com.github.bumptech.glide:compiler:$glide_version"
+
+    // ViewModel and LiveData Dependency
+    def lifecycle_version = '2.1.0-alpha03'
+    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DaggerSandbox">
-        <activity android:name=".AuthActivity">
+        <activity android:name=".ui.auth.AuthActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
@@ -1,9 +1,8 @@
 package com.thedancercodes.daggersandbox.di;
 
-import com.thedancercodes.daggersandbox.AuthActivity;
+import com.thedancercodes.daggersandbox.ui.auth.AuthActivity;
 
 import dagger.Module;
-import dagger.Provides;
 import dagger.android.ContributesAndroidInjector;
 
 /**
@@ -12,7 +11,9 @@ import dagger.android.ContributesAndroidInjector;
 @Module
 public abstract class ActivityBuildersModule {
 
-    @ContributesAndroidInjector
+    @ContributesAndroidInjector(
+            modules = {AuthViewModelsModule.class}
+    )
     abstract AuthActivity contributeAuthActivity();
 
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppComponent.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppComponent.java
@@ -26,6 +26,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
                 AndroidSupportInjectionModule.class,
                 ActivityBuildersModule.class,
                 AppModule.class,
+                ViewModelFactoryModule.class
         }
 )
 public interface AppComponent extends AndroidInjector<BaseApplication> {

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AuthViewModelsModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AuthViewModelsModule.java
@@ -1,0 +1,25 @@
+package com.thedancercodes.daggersandbox.di;
+
+import androidx.lifecycle.ViewModel;
+
+import com.thedancercodes.daggersandbox.ui.auth.AuthViewModel;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoMap;
+
+/**
+ * Responsible for dependencies for the AuthViewModel.
+ *
+ * Responsible for injecting the ViewModel for AuthViewModel.
+ */
+@Module
+public abstract class AuthViewModelsModule {
+
+    @Binds
+    @IntoMap // Mapping into a Key
+    @ViewModelKey(AuthViewModel.class) // This dependency/class is getting mapped to the key
+    public abstract ViewModel bindAuthViewModel(AuthViewModel viewModel);
+
+
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ViewModelFactoryModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ViewModelFactoryModule.java
@@ -1,0 +1,20 @@
+package com.thedancercodes.daggersandbox.di;
+
+import androidx.lifecycle.ViewModelProvider;
+
+import com.thedancercodes.daggersandbox.viewmodels.ViewModelProviderFactory;
+
+import dagger.Binds;
+import dagger.Module;
+
+/**
+ * Responsible for providing the dependencies during dependency injection for the
+ * ViewModelProviderFactory class.
+ */
+@Module
+public abstract class ViewModelFactoryModule {
+
+    // Providing an instance of the ViewModelProvider Factory.
+    @Binds
+    public abstract ViewModelProvider.Factory bindViewModelFactory(ViewModelProviderFactory modelProviderFactory);
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ViewModelKey.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ViewModelKey.java
@@ -1,0 +1,27 @@
+package com.thedancercodes.daggersandbox.di;
+
+import androidx.lifecycle.ViewModel;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import dagger.MapKey;
+
+
+/**
+ * ViewModelKey is a MapKey - Can be used to map similar dependencies and group them together.
+ */
+
+@Documented
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@MapKey
+public @interface ViewModelKey {
+
+    // Define the type of mapping - some class that extends ViewModel
+    Class<? extends ViewModel> value();
+
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/PlaceHolder.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/PlaceHolder.java
@@ -1,0 +1,4 @@
+package com.thedancercodes.daggersandbox.ui;
+
+public class PlaceHolder {
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthActivity.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthActivity.java
@@ -1,6 +1,7 @@
-package com.thedancercodes.daggersandbox;
+package com.thedancercodes.daggersandbox.ui.auth;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProviders;
 
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -8,6 +9,8 @@ import android.util.Log;
 import android.widget.ImageView;
 
 import com.bumptech.glide.RequestManager;
+import com.thedancercodes.daggersandbox.R;
+import com.thedancercodes.daggersandbox.viewmodels.ViewModelProviderFactory;
 
 import javax.inject.Inject;
 
@@ -16,6 +19,12 @@ import dagger.android.support.DaggerAppCompatActivity;
 public class AuthActivity extends DaggerAppCompatActivity {
 
     private static final String TAG = "AuthActivity";
+
+    private AuthViewModel viewModel;
+
+    // Used to instantiate the ViewModel
+    @Inject
+    ViewModelProviderFactory providerFactory;
 
     @Inject
     Drawable logo;
@@ -27,6 +36,9 @@ public class AuthActivity extends DaggerAppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_auth);
+
+        // Instantiate the ViewModel
+        viewModel = ViewModelProviders.of(this, providerFactory).get(AuthViewModel.class);
 
         setLogo();
     }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthViewModel.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthViewModel.java
@@ -1,0 +1,17 @@
+package com.thedancercodes.daggersandbox.ui.auth;
+
+import android.util.Log;
+
+import androidx.lifecycle.ViewModel;
+
+import javax.inject.Inject;
+
+public class AuthViewModel extends ViewModel {
+
+    private static final String TAG = "AuthViewModel";
+
+    @Inject
+    public AuthViewModel() {
+        Log.d(TAG, "AuthViewModel: ViewModel is working...");
+    }
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/viewmodels/ViewModelProviderFactory.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/viewmodels/ViewModelProviderFactory.java
@@ -1,0 +1,59 @@
+package com.thedancercodes.daggersandbox.viewmodels;
+
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/**
+ * This class facilitates injecting the ViewModels.
+ */
+public class ViewModelProviderFactory implements ViewModelProvider.Factory {
+
+    private static final String TAG = "ViewModelProviderFactor";
+
+    private final Map<Class<? extends ViewModel>, Provider<ViewModel>> creators;
+
+    /*
+     * Injecting a Map where the keys are the Classes of some ViewModel and the values are the
+     * ViewModels wrapped in a Provider.
+     */
+    @Inject
+    public ViewModelProviderFactory(Map<Class<? extends ViewModel>, Provider<ViewModel>> creators) {
+        this.creators = creators;
+    }
+
+    @Override
+    public <T extends ViewModel> T create(Class<T> modelClass) {
+        Provider<? extends ViewModel> creator = creators.get(modelClass);
+
+        // If the viewmodel has not been created
+        if (creator == null) {
+
+            // Loop through the allowable keys (aka allowed classes with the @ViewModelKey)
+            for (Map.Entry<Class<? extends ViewModel>, Provider<ViewModel>> entry : creators.entrySet()) {
+
+                // if it's allowed, set the Provider<ViewModel>
+                if (modelClass.isAssignableFrom(entry.getKey())) {
+                    creator = entry.getValue();
+                    break;
+                }
+            }
+        }
+
+        // If this is not one of the allowed keys, throw exception
+        if (creator == null) {
+            throw new IllegalArgumentException("unknown model class " + modelClass);
+        }
+
+        // Return the Provider
+        try {
+            return (T) creator.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
* Create ViewModelProviderFactory.
* Inject ViewModelProviderFactory into AuthActivity because ViewModel will be used here.
* Add ViewModel and LiveData dependencies to `build.gradle`
* Instantiate AuthViewModel object in AuthActivity.
* Multi-binding - Adding different dependencies into a group, marking them with a key and then you can inject them places.
    * We will use same providerFactory in all view models.
    * Mark all the view models with a specific key so that they can associate with each other and the same factory.
    * Create `@Annotation` file in /di called ViewModelKey
    * Use the `@MapKey` annotation to mark the file as a MapKey. Something that can be used to map similar dependencies and group them together.
* Setting the ViewModel classes to the key.
* auth/AuthViewModelsModule
    * Currently mapping a single ViewModel to our multi-binding.
* Add new modules created to the AppComponent and ActivityBuildersModule.
    * AppComponent - add ViewModelFactoryModule. It will be used by all the ViewModels in the project hence why we make it a singleton scoped application-level dependency.
    * AuthViewModelsModule - this will be scoped to the AuthComponent sub-component.
        * Add it as a module in ActivityBuildersModule.
        * **NOTE:** Only the AuthActivity sub-component will be able to use the module.