### PR TITLE
Inject Retrofit Singleton with Dagger 2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,4 +56,9 @@ dependencies {
     def lifecycle_version = '2.1.0-alpha03'
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
 
+    // Retrofit Dependencies
+    def retrofit_version = "2.5.0"
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
@@ -1,19 +1,26 @@
 package com.thedancercodes.daggersandbox.di;
 
+import com.thedancercodes.daggersandbox.di.auth.AuthModule;
+import com.thedancercodes.daggersandbox.di.auth.AuthViewModelsModule;
 import com.thedancercodes.daggersandbox.ui.auth.AuthActivity;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
 
 /**
- * Contains the potential clients that you can inject into.
+ * ActivityBuildersModule is representative of the AuthComponent (AuthActivity SubComponent).
+ *
+ * Contains the potential clients that you can inject into - AuthActivity.
+ *
+ * NOTE: Both AuthViewModelsModule & AuthModule exist inside the AuthActivity SubComponent.
+ *
+ * NOTE: The AuthActivity SubComponent is a SubComponent of the AppComponent.
  */
 @Module
 public abstract class ActivityBuildersModule {
 
     @ContributesAndroidInjector(
-            modules = {AuthViewModelsModule.class}
-    )
+            modules = {AuthViewModelsModule.class, AuthModule.class})
     abstract AuthActivity contributeAuthActivity();
 
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
@@ -9,11 +9,14 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.request.RequestOptions;
 import com.thedancercodes.daggersandbox.R;
+import com.thedancercodes.daggersandbox.util.Constants;
 
 import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
  * AppModule will be used inside the AppComponent.
@@ -25,6 +28,15 @@ import dagger.Provides;
 
 @Module
 public class AppModule {
+
+    @Singleton
+    @Provides
+    static Retrofit provideRetrofitInstance() {
+        return new Retrofit.Builder()
+                .baseUrl(Constants.BASE_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+    }
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthModule.java
@@ -1,0 +1,22 @@
+package com.thedancercodes.daggersandbox.di.auth;
+
+import com.thedancercodes.daggersandbox.network.auth.AuthApi;
+
+import dagger.Module;
+import dagger.Provides;
+import retrofit2.Retrofit;
+
+/**
+ * Contains all the dependencies for the Auth SubComponent.
+ *
+ * NOTE: We can access the Retrofit instance here because the AuthModule is inside a SubComponent;
+ *       See ActivityBuildersModule.
+ */
+@Module
+public class AuthModule {
+
+    @Provides
+    static AuthApi provideAuthApi(Retrofit retrofit) {
+        return retrofit.create(AuthApi.class);
+    }
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthViewModelsModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthViewModelsModule.java
@@ -1,7 +1,8 @@
-package com.thedancercodes.daggersandbox.di;
+package com.thedancercodes.daggersandbox.di.auth;
 
 import androidx.lifecycle.ViewModel;
 
+import com.thedancercodes.daggersandbox.di.ViewModelKey;
 import com.thedancercodes.daggersandbox.ui.auth.AuthViewModel;
 
 import dagger.Binds;

--- a/app/src/main/java/com/thedancercodes/daggersandbox/network/auth/AuthApi.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/network/auth/AuthApi.java
@@ -1,0 +1,15 @@
+package com.thedancercodes.daggersandbox.network.auth;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+/**
+ * Interface that holds the methods for accessing the API endpoints required for Authentication.
+ */
+public interface AuthApi {
+
+    @GET
+    Call<ResponseBody> getFakeStuff();
+
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/PlaceHolder.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/PlaceHolder.java
@@ -1,4 +1,0 @@
-package com.thedancercodes.daggersandbox.ui;
-
-public class PlaceHolder {
-}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthViewModel.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthViewModel.java
@@ -4,14 +4,26 @@ import android.util.Log;
 
 import androidx.lifecycle.ViewModel;
 
+import com.thedancercodes.daggersandbox.network.auth.AuthApi;
+
 import javax.inject.Inject;
 
 public class AuthViewModel extends ViewModel {
 
     private static final String TAG = "AuthViewModel";
 
+    private final AuthApi authApi;
+
     @Inject
-    public AuthViewModel() {
+    public AuthViewModel(AuthApi authApi) {
+        this.authApi = authApi;
         Log.d(TAG, "AuthViewModel: ViewModel is working...");
+
+        // Check that the AuthApi is being injected as a dependency.
+        if (this.authApi == null) {
+            Log.d(TAG, "AuthViewModel: auth api is NULL.");
+        } else {
+            Log.d(TAG, "AuthViewModel: auth api is NOT NULL.");
+        }
     }
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/util/Constants.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/util/Constants.java
@@ -1,0 +1,7 @@
+package com.thedancercodes.daggersandbox.util;
+
+public class Constants {
+
+    public static final String BASE_URL="https://jsonplaceholder.typicode.com";
+
+}


### PR DESCRIPTION
* Set up retrofit

* Use retrofit as a dependency and inject it with dagger.

* util/Constants.java
   * Add the base URL here.

* Declare Retrofit dependency in the AppModule; because the retrofit instance will exist for the entire lifetime of the application.

* Build an interface that holds the methods for accessing the api.
  * NOTE: The authentication methods are only needed in the AuthComponent. Hence we will create it as a subcomponent dependency.

  * network/auth/AuthApi

  * di/auth/AuthModule
      * Contains all the dependencies for the Auth subcomponent.

* ActivityBuildersModule
      * Add AuthApi inside the Auth SubComponent.

* ui/auth/AuthViewModel
  * Inject the API (AuthApi) into the ViewModel constructor.

* Conclusion:
  * Successfully created retrofit instance, leveraged it inside AuthModule and injected another dependency into the AuthViewModel.