### PR TITLE
Retrofit Calls and RxJava

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,4 +61,12 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
 
+    // RxJava Dependency
+    def rxjava_version = '2.1.1'
+    implementation "io.reactivex.rxjava2:rxjava:$rxjava_version"
+
+    // Rx-Retrofit Call Adapter Dependency
+    def rx_call_adapter_version = '2.5.0'
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$rx_call_adapter_version"
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.thedancercodes.daggersandbox">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".BaseApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
@@ -16,6 +16,7 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
@@ -34,6 +35,7 @@ public class AppModule {
     static Retrofit provideRetrofitInstance() {
         return new Retrofit.Builder()
                 .baseUrl(Constants.BASE_URL)
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create())
                 .build();
     }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/models/User.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/models/User.java
@@ -1,0 +1,69 @@
+package com.thedancercodes.daggersandbox.models;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * User model
+ * This is the model for the API response to get User data.
+ */
+public class User {
+
+    @SerializedName("id")
+    @Expose
+    private int id;
+
+    @SerializedName("username")
+    @Expose
+    private String username;
+
+    @SerializedName("email")
+    @Expose
+    private String email;
+
+    @SerializedName("website")
+    @Expose
+    private String website;
+
+    public User(int id, String username, String email, String website) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.website = website;
+    }
+
+    public User() {
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getWebsite() {
+        return website;
+    }
+
+    public void setWebsite(String website) {
+        this.website = website;
+    }
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/network/auth/AuthApi.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/network/auth/AuthApi.java
@@ -1,15 +1,17 @@
 package com.thedancercodes.daggersandbox.network.auth;
 
-import okhttp3.ResponseBody;
-import retrofit2.Call;
+import com.thedancercodes.daggersandbox.models.User;
+
+import io.reactivex.Flowable;
 import retrofit2.http.GET;
+import retrofit2.http.Path;
 
 /**
  * Interface that holds the methods for accessing the API endpoints required for Authentication.
  */
 public interface AuthApi {
 
-    @GET
-    Call<ResponseBody> getFakeStuff();
+    @GET("users/{id}")
+    Flowable<User> getUser(@Path("id") int id);
 
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthViewModel.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthViewModel.java
@@ -4,9 +4,15 @@ import android.util.Log;
 
 import androidx.lifecycle.ViewModel;
 
+import com.thedancercodes.daggersandbox.models.User;
 import com.thedancercodes.daggersandbox.network.auth.AuthApi;
 
 import javax.inject.Inject;
+
+import io.reactivex.Observer;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 
 public class AuthViewModel extends ViewModel {
 
@@ -19,11 +25,30 @@ public class AuthViewModel extends ViewModel {
         this.authApi = authApi;
         Log.d(TAG, "AuthViewModel: ViewModel is working...");
 
-        // Check that the AuthApi is being injected as a dependency.
-        if (this.authApi == null) {
-            Log.d(TAG, "AuthViewModel: auth api is NULL.");
-        } else {
-            Log.d(TAG, "AuthViewModel: auth api is NOT NULL.");
-        }
+        // Make request and run it on a background thread
+        authApi.getUser(1)
+                .toObservable() // Convert Flowable object to an Observable
+                .subscribeOn(Schedulers.io()) // Subscribe on a background thread
+                .subscribe(new Observer<User>() { // New observer to observe the Observable
+                    @Override
+                    public void onSubscribe(@NonNull Disposable d) {
+
+                    }
+
+                    @Override
+                    public void onNext(@NonNull User user) {
+                        Log.d(TAG, "onNext: " + user.getEmail());
+                    }
+
+                    @Override
+                    public void onError(@NonNull Throwable e) {
+                        Log.e(TAG, "onError: ", e);
+                    }
+
+                    @Override
+                    public void onComplete() {
+
+                    }
+                });
     }
 }


### PR DESCRIPTION
* Get Rx dependencies required to return a Flowable object from the Retrofit request.

* Inside the ViewModel, we can convert the Flowable object into a LiveData object.

* Add RxJava dependency.

* Add RxJava Retrofit Adapter to convert retrofit Call objects to Flowable objects.
  * https://github.com/square/retrofit/tree/master/retrofit-adapters/rxjava2

* `AppModule` - apply the rx retrofit adapter to the retrofit instance.

* Model the response to return the data we require.
  * Build the real model for the response.
  * `models/User.java`

* `AuthApi` - return Flowable object from the Retrofit call. Set it up to receive a parameter of user **id**.

* Add internet permissions in `AndroidManifest.xml`

* `AuthViewModel` - Perform a test request to ensure everything is working.
  * Since API is already injected, we just need to make the request.