### PR TITLE
Managing Authentication with Dagger - Part 3

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.main.MainActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/thedancercodes/daggersandbox/BaseActivity.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/BaseActivity.java
@@ -1,0 +1,78 @@
+package com.thedancercodes.daggersandbox;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.lifecycle.Observer;
+
+import com.thedancercodes.daggersandbox.models.User;
+import com.thedancercodes.daggersandbox.ui.auth.AuthActivity;
+import com.thedancercodes.daggersandbox.ui.auth.AuthResource;
+
+import javax.inject.Inject;
+
+import dagger.android.support.DaggerAppCompatActivity;
+
+/**
+ * Abstract because we will be extending our other activities by this class.
+ */
+public abstract class BaseActivity extends DaggerAppCompatActivity {
+
+    private static final String TAG = "BaseActivity";
+
+    // Inject SessionManager to keep track of user's authentication state in every
+    // Activity/ Fragment of the Application.
+    @Inject
+    public SessionManager sessionManager;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        subscribeObservers();
+    }
+
+    // Observe Authentication State
+    private void subscribeObservers() {
+        sessionManager.getAuthUser().observe(this, new Observer<AuthResource<User>>() {
+            @Override
+            public void onChanged(AuthResource<User> userAuthResource) {
+
+                // Ensure userAuthResource isn't null
+                if (userAuthResource != null) {
+                    switch (userAuthResource.status) {
+
+                        // Check what the status is and switch it
+                        case LOADING: {
+                            break;
+                        }
+
+                        case AUTHENTICATED: {
+                            Log.d(TAG, "onChanged: LOGIN SUCCESS: "
+                                    + userAuthResource.data.getEmail());
+                            break;
+                        }
+
+                        case ERROR: {
+                            break;
+                        }
+
+                        case NOT_AUTHENTICATED: {
+                            navLoginScreen();
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Redirect user to login screen if they are not authenticated.
+    private void navLoginScreen() {
+        Intent intent = new Intent(this, AuthActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
@@ -3,6 +3,7 @@ package com.thedancercodes.daggersandbox.di;
 import com.thedancercodes.daggersandbox.di.auth.AuthModule;
 import com.thedancercodes.daggersandbox.di.auth.AuthViewModelsModule;
 import com.thedancercodes.daggersandbox.ui.auth.AuthActivity;
+import com.thedancercodes.daggersandbox.ui.main.MainActivity;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
@@ -22,5 +23,8 @@ public abstract class ActivityBuildersModule {
     @ContributesAndroidInjector(
             modules = {AuthViewModelsModule.class, AuthModule.class})
     abstract AuthActivity contributeAuthActivity();
+
+    @ContributesAndroidInjector()
+    abstract MainActivity contributeMainActivity();
 
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthActivity.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthActivity.java
@@ -3,6 +3,7 @@ package com.thedancercodes.daggersandbox.ui.auth;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProviders;
 
+import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -16,6 +17,7 @@ import android.widget.Toast;
 import com.bumptech.glide.RequestManager;
 import com.thedancercodes.daggersandbox.R;
 import com.thedancercodes.daggersandbox.models.User;
+import com.thedancercodes.daggersandbox.ui.main.MainActivity;
 import com.thedancercodes.daggersandbox.viewmodels.ViewModelProviderFactory;
 
 import javax.inject.Inject;
@@ -89,6 +91,7 @@ public class AuthActivity extends DaggerAppCompatActivity implements View.OnClic
                             showProgressBar(false);
                             Log.d(TAG, "onChanged: LOGIN SUCCESS: "
                                     + userAuthResource.data.getEmail());
+                            onLoginSuccess();
                             break;
                         }
 
@@ -117,6 +120,13 @@ public class AuthActivity extends DaggerAppCompatActivity implements View.OnClic
         } else {
             progressBar.setVisibility(View.GONE);
         }
+    }
+
+    // Method to redirect to MainActivity when a user is authenticated
+    private void onLoginSuccess() {
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+        finish();
     }
 
     // Method to set a logo

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/main/MainActivity.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/main/MainActivity.java
@@ -1,0 +1,22 @@
+package com.thedancercodes.daggersandbox.ui.main;
+
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+
+import com.thedancercodes.daggersandbox.BaseActivity;
+import com.thedancercodes.daggersandbox.R;
+
+public class MainActivity extends BaseActivity {
+
+    private static final String TAG = "MainActivity";
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        Toast.makeText(this, "MainActivity", Toast.LENGTH_SHORT).show();
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="15dp"
+    android:background="#fff">
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* Creating **MainActivity** and getting the MainComponent set up.

* Create a **BaseActivity** - abstract class that other activities will extend.

* Inject session manager into BaseActivity.

* ui/main/MainActivity
  * Add activity to manifest file.
  * Create `activity_main` layout file.

* AuthActivity
  * Create a way to redirect to MainActivity when a user is authenticated.
  * `onLoginSuccess()` method.

* NOTE: If the user is authenticated, the authentication state will be observed by the **SessionManager** and will redirect to the **MainActivity**.
  * Once in **MainActivity**, we will be observing the authentication state from the **BaseActivity** using the **SessionManager**.

* Add MainActivity into the **ActivityBuildersModule**.
  * Since we are using the DaggerAndroid imports, we need to add all of our sub-components or activities using the `@ContributesAndroidInjector`.