### PR TITLE
SubComponent Dependencies with Dagger 2

### DIFF
--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
@@ -3,6 +3,7 @@ package com.thedancercodes.daggersandbox.di;
 import com.thedancercodes.daggersandbox.di.auth.AuthModule;
 import com.thedancercodes.daggersandbox.di.auth.AuthViewModelsModule;
 import com.thedancercodes.daggersandbox.di.main.MainFragmentBuildersModule;
+import com.thedancercodes.daggersandbox.di.main.MainModule;
 import com.thedancercodes.daggersandbox.di.main.MainViewModelsModule;
 import com.thedancercodes.daggersandbox.ui.auth.AuthActivity;
 import com.thedancercodes.daggersandbox.ui.main.MainActivity;
@@ -28,7 +29,8 @@ public abstract class ActivityBuildersModule {
     abstract AuthActivity contributeAuthActivity();
 
     @ContributesAndroidInjector(
-            modules = {MainFragmentBuildersModule.class, MainViewModelsModule.class}
+            modules = {MainFragmentBuildersModule.class,
+                    MainViewModelsModule.class, MainModule.class}
     )
     abstract MainActivity contributeMainActivity();
 

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/main/MainModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/main/MainModule.java
@@ -1,0 +1,25 @@
+package com.thedancercodes.daggersandbox.di.main;
+
+import com.thedancercodes.daggersandbox.network.main.MainApi;
+
+import dagger.Module;
+import dagger.Provides;
+import retrofit2.Retrofit;
+
+/**
+ * Contains all the dependencies for the MainActivity SubComponent.
+ *
+ * NOTE: We can access the Retrofit instance here because the MainModule is inside a SubComponent;
+ *       See ActivityBuildersModule.
+ *
+ * NOTE: The MainApi only exists within the MainComponent, it can't be accessed in the AuthComponent
+ */
+@Module
+public class MainModule {
+
+    @Provides
+    static MainApi provideMainApi(Retrofit retrofit) {
+        return retrofit.create(MainApi.class);
+    }
+
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/models/Post.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/models/Post.java
@@ -1,0 +1,65 @@
+package com.thedancercodes.daggersandbox.models;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Post {
+
+    @SerializedName("userId")
+    @Expose
+    private int userId;
+
+    @SerializedName("id")
+    @Expose
+    private int id;
+
+    @SerializedName("title")
+    @Expose
+    private String title;
+
+    @SerializedName("body")
+    @Expose
+    private String body;
+
+    public Post(int userId, int id, String title, String body) {
+        this.userId = userId;
+        this.id = id;
+        this.title = title;
+        this.body = body;
+    }
+
+    public Post() {
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/network/main/MainApi.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/network/main/MainApi.java
@@ -1,0 +1,21 @@
+package com.thedancercodes.daggersandbox.network.main;
+
+import com.thedancercodes.daggersandbox.models.Post;
+
+import java.util.List;
+
+import io.reactivex.Flowable;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+/**
+ * Interface that holds the methods for accessing the API endpoints required for retrieving Posts.
+ */
+public interface MainApi {
+
+    // posts?userId=1
+    @GET
+    Flowable<List<Post>> getPostsFromUser(
+            @Query("userId") int id
+    );
+}


### PR DESCRIPTION
* Example of how to specify dependencies in a particular sub-component and then only use this dependencies in that sub-component.
  * NOTE: The dependencies are only accessible in the scope of that sub-component.

* PostFragment
  * Will be querying a different part of the API.

* Create a new Post model object, new API class for retrofit, create a new module and add it to the MainActivity SubComponent.

* models/Post
  * Modelling the Post object from the API.

* network/main/MainApi

* NOTE: Difference in Retrofit annotations.
  * `@Path` appends a **"/"** while `@Query` appends a **"?"**

* di/main/MainModule
  * This module contains dependencies that can only be accessed in the MainActivity SubComponent.

* Add this module to the MainActivity SubComponent.
  * Do this in the ActivityBuildersModule.