### PR TITLE
Scoping SubComponents with Dagger 2

### DIFF
--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/ActivityBuildersModule.java
@@ -1,9 +1,11 @@
 package com.thedancercodes.daggersandbox.di;
 
 import com.thedancercodes.daggersandbox.di.auth.AuthModule;
+import com.thedancercodes.daggersandbox.di.auth.AuthScope;
 import com.thedancercodes.daggersandbox.di.auth.AuthViewModelsModule;
 import com.thedancercodes.daggersandbox.di.main.MainFragmentBuildersModule;
 import com.thedancercodes.daggersandbox.di.main.MainModule;
+import com.thedancercodes.daggersandbox.di.main.MainScope;
 import com.thedancercodes.daggersandbox.di.main.MainViewModelsModule;
 import com.thedancercodes.daggersandbox.ui.auth.AuthActivity;
 import com.thedancercodes.daggersandbox.ui.main.MainActivity;
@@ -24,10 +26,12 @@ import dagger.android.ContributesAndroidInjector;
 @Module
 public abstract class ActivityBuildersModule {
 
+    @AuthScope
     @ContributesAndroidInjector(
             modules = {AuthViewModelsModule.class, AuthModule.class})
     abstract AuthActivity contributeAuthActivity();
 
+    @MainScope
     @ContributesAndroidInjector(
             modules = {MainFragmentBuildersModule.class,
                     MainViewModelsModule.class, MainModule.class}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthModule.java
@@ -15,6 +15,7 @@ import retrofit2.Retrofit;
 @Module
 public class AuthModule {
 
+    @AuthScope
     @Provides
     static AuthApi provideAuthApi(Retrofit retrofit) {
         return retrofit.create(AuthApi.class);

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthScope.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthScope.java
@@ -1,0 +1,14 @@
+package com.thedancercodes.daggersandbox.di.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import javax.inject.Scope;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Scope
+@Documented
+@Retention(RUNTIME)
+public @interface AuthScope {
+}

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/main/MainModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/main/MainModule.java
@@ -21,11 +21,13 @@ public class MainModule {
     /*
      * Allow us to inject the adapter as a dependency.
      */
+    @MainScope
     @Provides
     static PostRecyclerAdapter provideAdapter() {
         return new PostRecyclerAdapter();
     }
 
+    @MainScope
     @Provides
     static MainApi provideMainApi(Retrofit retrofit) {
         return retrofit.create(MainApi.class);

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/main/MainScope.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/main/MainScope.java
@@ -1,0 +1,14 @@
+package com.thedancercodes.daggersandbox.di.main;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import javax.inject.Scope;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Scope
+@Documented
+@Retention(RUNTIME)
+public @interface MainScope {
+}


### PR DESCRIPTION
* `@Singleton` - takes care of app-wide scope.

* `@AuthScope` - takes care of dependencies related to authentication.

* `@MainScope` - for MainActivity SubComponent.
  * Related to dependencies and API calls when used has been logged in

* di/auth/AuthScope
  * Apply scope to a particular component or SubComponent:
    * The component owns the scope once you apply it to the component.
    * Add `@AuthScope` to AuthActivity SubComponent in ActivityBuildersModule
    * Add `@AuthScope` to AuthModule

* di/main/MainScope
  * Add `@MainScope` to MainActivity SubComponent in ActivityBuildersModule
  * The MainActivity SubComponent now owns the MainScope.
  * Add `@MainScope` to MainModule.