### PR TITLE
Scoping with Dagger 2 Examples

### DIFF
--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/AppModule.java
@@ -9,8 +9,10 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.request.RequestOptions;
 import com.thedancercodes.daggersandbox.R;
+import com.thedancercodes.daggersandbox.models.User;
 import com.thedancercodes.daggersandbox.util.Constants;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -62,6 +64,13 @@ public class AppModule {
     @Provides
     static Drawable provideAppDrawable(Application application) {
         return ContextCompat.getDrawable(application, R.drawable.logo);
+    }
+
+    @Singleton
+    @Provides
+    @Named("app_user")
+    static User someUser() {
+        return new User();
     }
 
 }

--- a/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthModule.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/di/auth/AuthModule.java
@@ -1,6 +1,10 @@
 package com.thedancercodes.daggersandbox.di.auth;
 
+import com.thedancercodes.daggersandbox.models.User;
 import com.thedancercodes.daggersandbox.network.auth.AuthApi;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
@@ -14,6 +18,13 @@ import retrofit2.Retrofit;
  */
 @Module
 public class AuthModule {
+
+    @AuthScope
+    @Provides
+    @Named("auth_user")
+    static User someUser() {
+        return new User();
+    }
 
     @AuthScope
     @Provides

--- a/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthActivity.java
+++ b/app/src/main/java/com/thedancercodes/daggersandbox/ui/auth/AuthActivity.java
@@ -21,6 +21,7 @@ import com.thedancercodes.daggersandbox.ui.main.MainActivity;
 import com.thedancercodes.daggersandbox.viewmodels.ViewModelProviderFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import dagger.android.support.DaggerAppCompatActivity;
 
@@ -44,6 +45,14 @@ public class AuthActivity extends DaggerAppCompatActivity implements View.OnClic
     @Inject
     RequestManager requestManager; // The Glide Instance
 
+    @Inject
+    @Named("app_user")
+    User userNumber1;
+
+    @Inject
+    @Named("auth_user")
+    User userNumber2;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -64,6 +73,9 @@ public class AuthActivity extends DaggerAppCompatActivity implements View.OnClic
         setLogo();
 
         subscribeObservers();
+
+        Log.d(TAG, "onCreate: app_user ~> " + userNumber1); // From @Singleton scope
+        Log.d(TAG, "onCreate: auth_user ~> " + userNumber2); // From @AuthScope scope
     }
 
     // This method helps us observe the MediatorLiveData object (authUser) in AuthViewModel


### PR DESCRIPTION
* AppModule
  * Create a new User object dependency.

* Inject this new User object in AuthActivity.

* Add same dependency to User object.
  * Replace `@Singleton` with `@AuthScope`

* **NOTE**: If you create 2 different dependencies that return the same object type, you will experience an error.
  * You can differentiate them using the `@Named` annotation to enable Dagger to differentiate between the two dependencies.